### PR TITLE
Fix: `usermod: group '...' does not exist` with custom GITEA_RUNNER_GID

### DIFF
--- a/image/run.sh
+++ b/image/run.sh
@@ -42,7 +42,7 @@ if [ -n "${GITEA_RUNNER_GID:-}" ]; then
   effective_gid=$(id -g act)
   if [ "$GITEA_RUNNER_GID" != "$effective_gid" ]; then
     log INFO "Changing GID of user [act] from $effective_gid to $GITEA_RUNNER_GID..."
-    sudo usermod -o -g "$GITEA_RUNNER_GID" act
+    sudo groupmod -o -g "$GITEA_RUNNER_GID" act
   fi
 fi
 sudo chown -R act:act /data


### PR DESCRIPTION
Second attempt to fix the GITEA_RUNNER_GID envar issue. See previous issue [#5](https://github.com/vegardit/docker-gitea-act-runner/issues/).

Tested this GITEA_RUNNER_GID envar fix without building the upstream image, as that was problematic to achieve locally.

The fixed image requires either compose: `user: root` OR `restart: always` (or `unless-stopped`). Why? The UID change in `/opt/run.sh` fails during the container's first execution, at the next `sudo` command within `/opt/run.sh`

Basically: changing the running UID's `/etc/passwd` entry causes the next sudo command to fail.

The container restart (without wiping the read/write layer) starts with the already changed `/etc/passwd`, and then continues without the `sudo` error.

See associated issue [#9](https://github.com/vegardit/docker-gitea-act-runner/issues/9) for testing method.