### PR TITLE
config.template.yaml - replace backticks with quotes

### DIFF
--- a/image/config.template.yaml
+++ b/image/config.template.yaml
@@ -36,7 +36,7 @@ runner:
   # The labels of a runner are used to determine which jobs the runner can run, and how to run them.
   # Like: ["macos-arm64:host", "ubuntu-latest:docker://node:16-bullseye", "ubuntu-22.04:docker://node:16-bullseye"]
   # If it's empty when registering, it will ask for inputting labels.
-  # If it's empty when execute `deamon`, will use labels in `.runner` file.
+  # If it's empty when execute "daemon", will use labels in ".runner" file.
   #labels: []
 
 cache:


### PR DESCRIPTION
Replace the backtick characters introduced in xxx with double quotes. This fixes the /opt/run-runner.sh container startup failure.

This fixes the backticks introduced by commit 5dd9107.