### PR TITLE
fix: correct error `'/var/run/docker.sock': No such file or directory` when `GITEA_RUNNER_JOB_CONTAINER_DOCKER_HOST` is set

### DIFF
--- a/image/run.sh
+++ b/image/run.sh
@@ -104,19 +104,22 @@ fi
 
 
 #################################################################
-# check if act user has read/write access to /var/run/docker.sock
+# check if act user has read/write access to docker socket in GITEA_RUNNER_JOB_CONTAINER_DOCKER_HOST
 #################################################################
 if [[ $DOCKER_MODE != "dind-rootless" ]]; then
-  if [[ ! -w /var/run/docker.sock || ! -r /var/run/docker.sock ]]; then
-    docker_group=$(stat -c '%G' /var/run/docker.sock)
-    if [[ $docker_group == "UNKNOWN" ]]; then
-      docker_gid=$(stat -c '%g' /var/run/docker.sock)
-      docker_group="docker$docker_gid"
-      fix_permissions=true
-    fi
+  if [[ $GITEA_RUNNER_JOB_CONTAINER_DOCKER_HOST == unix://* ]]; then
+    docker_sock=${GITEA_RUNNER_JOB_CONTAINER_DOCKER_HOST#unix://}
+    if [[ ! -w $docker_sock || ! -r $docker_sock ]]; then
+      docker_group=$(stat -c '%G' $docker_sock)
+      if [[ $docker_group == "UNKNOWN" ]]; then
+        docker_gid=$(stat -c '%g' $docker_sock)
+        docker_group="docker$docker_gid"
+        fix_permissions=true
+      fi
 
-    if ! id -nG act | grep -qw "$docker_group"; then
-      fix_permissions=true
+      if ! id -nG act | grep -qw "$docker_group"; then
+        fix_permissions=true
+      fi
     fi
   fi
 fi


### PR DESCRIPTION
- fix: #42

Docker Compose Case:
```yaml
version: "3.9"

networks:
  gitea:
    external: true
  socat:
    external: true

services:
  # ...

  gitea-act-runner:
    image: vegardit/gitea-act-runner:${GITEA_ACT_RUNNER_VERSION:-latest}
    depends_on:
      - gitea
    restart: on-failure
    networks:
      - gitea
      - socat
    environment:
      TZ: Asia/Shanghai
      GITEA_INSTANCE_URL: http://gitea:3000
      GITEA_RUNNER_REGISTRATION_TOKEN: ${GITEA_ACT_RUNNER_REGISTRATION_TOKEN}
      GITEA_RUNNER_NAME: ${GITEA_ACT_RUNNER_NAME:-act-runner}
      GITEA_RUNNER_LABELS: ${GITEA_ACT_RUNNER_LABELS}

      GITEA_RUNNER_JOB_CONTAINER_DOCKER_HOST: tcp://socat:2375
      GITEA_RUNNER_JOB_CONTAINER_NETWORK: gitea
      GITEA_RUNNER_JOB_CONTAINER_OPTIONS: >-
        --volume ${COMPOSE_FILE_DIR}/gitea_act_runner_data/cache/toolcache:/opt/hostedtoolcache
        --env TZ=Asia/Shanghai
      GITEA_RUNNER_VALID_VOLUME_1: ${COMPOSE_FILE_DIR}/gitea_act_runner_data/cache/toolcache
    volumes:
      - ./gitea_act_runner_data:/data
```

Error:
```log
2023-12-21 16:38:14 stat: cannot statx '/var/run/docker.sock': No such file or directory
2023-12-21 16:38:14 16:38:14 Error - exited with status 1 in [/opt/run.sh] at line 111:
2023-12-21 16:38:14    108      #################################################################
2023-12-21 16:38:14    109      if [[ $DOCKER_MODE != "dind-rootless" ]]; then
2023-12-21 16:38:14    110        if [[ ! -w /var/run/docker.sock || ! -r /var/run/docker.sock ]]; then
2023-12-21 16:38:14    111          docker_group=$(stat -c '%G' /var/run/docker.sock)
2023-12-21 16:38:14    112          if [[ $docker_group == "UNKNOWN" ]]; then
2023-12-21 16:38:14    113            docker_gid=$(stat -c '%g' /var/run/docker.sock)
2023-12-21 16:38:14    114            docker_group="docker$docker_gid"
```

