### PR TITLE
Fixed crash loop on renamed registration file

### DIFF
--- a/image/run_runner.sh
+++ b/image/run_runner.sh
@@ -47,7 +47,7 @@ fi
 #################################################
 # register act runner if required
 #################################################
-if [[ ! -s .runner ]]; then
+if [[ ! -s ${GITEA_RUNNER_REGISTRATION_FILE:-.runner} ]]; then
   if [[ -z ${GITEA_RUNNER_REGISTRATION_TOKEN:-} ]]; then
     read -r GITEA_RUNNER_REGISTRATION_TOKEN < "$GITEA_RUNNER_REGISTRATION_TOKEN_FILE"
   fi


### PR DESCRIPTION
When the user (e.g. "Me") decides to rename the file with the registration info, this could end in two ways, depending if `$GITEA_RUNNER_REGISTRATION_TOKEN_FILE` and `$GITEA_RUNNER_REGISTRATION_TOKEN` are set:

1. If one or both env var(s) is/are set, the runner will re-register on every restart of the container, resulting in numerous "offline" runners in gitea.
2. If neither env var is set, the runner will run into a crash loop, as it expects the `.runner` file or a token-source, neither of which are available.


PS: I was not able to test this as I ran into issues every step on the way to building the image.