### PR TITLE
feat: add git to required packages

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -104,6 +104,8 @@ RUN --mount=type=bind,source=.shared,target=/mnt/shared <<EOF
     echo "#################################################"
     echo "Installing docker engine..."
     echo "#################################################"
+    # git needed by buildx
+    apt-get install --no-install-recommends -y git
     # https://docs.docker.com/engine/install/debian/#install-using-the-repository
     apt-get install --no-install-recommends -y gnupg
     install -m 0755 -d /etc/apt/keyrings


### PR DESCRIPTION
The action [docker/build-push-action](https://github.com/docker/build-push-action) build Docker images with [buildx](https://github.com/docker/buildx).

The docker-build is something like remote-build, it runs the build process on the remote host.
In this case, we need `git` in the Docker-In-Docker container image.

Close #57
